### PR TITLE
Switching to Mimir-Aware Vizual API

### DIFF
--- a/resources/processors/mimir/vizual.yaml
+++ b/resources/processors/mimir/vizual.yaml
@@ -5,5 +5,7 @@ engine:
     moduleName: 'vizier.engine.packages.vizual.processor'
     properties:
         api:
-            className: 'DefaultVizualApi'
-            moduleName: 'vizier.engine.packages.vizual.api.fs'
+            className: 'MimirVizualApi'
+            moduleName: 'vizier.engine.packages.vizual.api.mimir'
+            # className: 'DefaultVizualApi'
+            # moduleName: 'vizier.engine.packages.vizual.api.fs'


### PR DESCRIPTION
- Mimir-Aware Vizual propagates caveats correctly (Closes #30)
- Mimir-Aware Vizual doesn't modify ROWIDs (Closes #55)