### PR TITLE
Magic output

### DIFF
--- a/vizier/engine/packages/pycell/processor.py
+++ b/vizier/engine/packages/pycell/processor.py
@@ -98,7 +98,7 @@ class PyCellTaskProcessor(TaskProcessor):
             python_cell_preload(variables)
             lines = [line for line in source.split('\n') if line.lstrip()[0] != '#'] # last executable line
             last = lines[-1]
-            if(last[0] == ' ' or last[0] == '\t' or 'print(' in  last): # if tabbed in or last line is already print don't override
+            if(source.split('\n')[0].lower() != '#!magicoutput' or last[0] == ' ' or last[0] == '\t' or 'print(' in  last): # if tabbed in or last line is already print don't override
                 exec(source, variables, variables)
             else:
                 last_get_type = "print("+lines[-1]+".__class__)"


### PR DESCRIPTION
Auto-magically converts pandas dataframe and matplotlib plot outputs to view friendly outputs. Matplotlib images are svg's for now, in future could use backend server. Has hacky sanity checks for if last line is comment or is for loop or is print statement.

Toggled on by making first line #!magicoutput

TODO: calls last line twice, which could be dangerous, needs to tie into execution engine better to obtain type safely