### PR TITLE
Mimir vizual native integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ resources/config/dev-config.yaml
 *.crc
 vizier_downloads/*
 
+/web-ui

--- a/.gitignore
+++ b/.gitignore
@@ -61,4 +61,5 @@ resources/config/dev-config.yaml
 /run.sh
 *.jar
 *.crc
+vizier_downloads/*
 

--- a/tools/vizier
+++ b/tools/vizier
@@ -161,7 +161,7 @@ trap "kill 0" EXIT
 
 if [ "$MIMIR_DEV" == "true" ]
   then
-    cd ../mimir; sbt "runMimirVizier --dataDirectory $USER_DATA_DIR" &
+    cd ../mimir-api; sbt "run --data-dir $USER_DATA_DIR" &
     cd ../web-api-async
   else
     ${APP_RESOURCES_DIR}mimir/mimir-api --dataDirectory $USER_DATA_DIR &

--- a/vizier/__init__.py
+++ b/vizier/__init__.py
@@ -1,0 +1,5 @@
+import os
+
+def debug_is_on():
+  return str(os.environ.get("DEBUG", "")) != ""
+

--- a/vizier/api/webservice/server.py
+++ b/vizier/api/webservice/server.py
@@ -541,6 +541,8 @@ def insert_workflow_module(project_id, branch_id, module_id):
         if not modules is None:
             return jsonify(modules)
     except ValueError as ex:
+        print(ex)
+        print(traceback.format_exc())
         raise srv.InvalidRequest(str(ex))
     raise srv.ResourceNotFound('unknown project \'' + project_id + '\' branch \'' + branch_id + '\' or module \'' + module_id + '\'')
 

--- a/vizier/datastore/mimir/base.py
+++ b/vizier/datastore/mimir/base.py
@@ -184,7 +184,7 @@ def get_select_query(table_name, columns=None):
     str
     """
     if not columns is None:
-        col_list = ','.join([col.name_in_rdb for col in columns])
+        col_list = ','.join(['`' + col.name_in_rdb + '`' for col in columns])
         return 'SELECT ' + col_list + ' FROM ' + table_name
     else:
         return 'SELECT ' + ROW_ID + ' FROM ' + table_name

--- a/vizier/datastore/mimir/dataset.py
+++ b/vizier/datastore/mimir/dataset.py
@@ -306,7 +306,7 @@ class MimirDatasetHandle(DatasetHandle):
             has_reasons = len(buffer) > 0
             if has_reasons:
                 for value in buffer:
-                    value = value['english']
+                    value = value['message']
                     if value != '':
                         annotations.append(
                             DatasetAnnotation(

--- a/vizier/datastore/mimir/dataset.py
+++ b/vizier/datastore/mimir/dataset.py
@@ -368,3 +368,11 @@ class MimirDatasetHandle(DatasetHandle):
         }
         with open(filename, 'w') as f:
             dump_json(doc, f)
+
+    def confirm_sync_with_mimir(self):
+        try:
+            sch = mimir.getSchema("SELECT * FROM `{}`".format(self.table_name))
+            return True
+        except mimir.MimirError:
+            return False
+

--- a/vizier/datastore/mimir/reader.py
+++ b/vizier/datastore/mimir/reader.py
@@ -114,7 +114,7 @@ class MimirDatasetReader(DatasetReader):
                     sql +=  ' LIMIT ' + str(self.limit)
                 if self.offset > 0:
                     sql += ' OFFSET ' + str(self.offset) 
-            rs = mimir.vistrailsQueryMimirJson(sql+ ';', True, False)
+            rs = mimir.vistrailsQueryMimirJson(sql, True, False)
             #self.row_ids = rs['prov']
             # Initialize mapping of column rdb names to index positions in
             # dataset rows

--- a/vizier/datastore/mimir/reader.py
+++ b/vizier/datastore/mimir/reader.py
@@ -136,7 +136,7 @@ class MimirDatasetReader(DatasetReader):
                     col = self.columns[i]
                     col_index = self.col_map[col.name_in_rdb]
                     values[i] = base.mimir_value_to_python(row[col_index], col)
-                    annotation_flag_values[i] = row_annotation_flags[col_index]
+                    annotation_flag_values[i] = not row_annotation_flags[col_index]
                 self.rows.append(DatasetRow(row_id, values, annotation_flag_values))
             self.read_index = 0
             self.is_open = True

--- a/vizier/datastore/mimir/store.py
+++ b/vizier/datastore/mimir/store.py
@@ -104,9 +104,9 @@ class MimirDatastore(DefaultDatastore):
                 )
             )
             if colSql == '':
-                colSql = col.name + ' AS ' + col.name
+                colSql = '`' + col.name + '` AS `' + col.name + '`'
             else:
-                colSql = colSql + ', ' + col.name + ' AS ' + col.name
+                colSql = colSql + ', `' + col.name + '` AS `' + col.name + '`'
         # Create CSV file for load
         with open(tmp_file, 'w') as f_out:
             writer = csv.writer(f_out, quoting=csv.QUOTE_MINIMAL)
@@ -483,9 +483,9 @@ class MimirDatastore(DefaultDatastore):
                 name_in_rdb=name_in_rdb
             )
             if colSql == '':
-                colSql = name_in_dataset + ' AS ' + name_in_rdb
+                colSql = '`' + name_in_dataset + '` AS `' + name_in_rdb + '`'
             else:
-                colSql = colSql + ', ' + name_in_dataset + ' AS ' + name_in_rdb
+                colSql = colSql + ', `' + name_in_dataset + '` AS `' + name_in_rdb + '`'
             columns.append(col)
         # Create view for loaded dataset
         sql = 'SELECT '+ colSql +' FROM '+init_load_name

--- a/vizier/datastore/mimir/store.py
+++ b/vizier/datastore/mimir/store.py
@@ -90,7 +90,7 @@ class MimirDatastore(DefaultDatastore):
         # Get unique identifier for new dataset
         identifier = 'DS_' + get_unique_identifier()
         # Write rows to temporary file in CSV format
-        tmp_file = os.path.abspath(self.base_path + identifier)
+        tmp_file = os.path.abspath(self.base_path + os.path.sep + identifier)
         # Create a list of columns that contain the user-vizible column name and
         # the name in the database
         db_columns = list()
@@ -114,9 +114,10 @@ class MimirDatastore(DefaultDatastore):
             for row in rows:
                 record = helper.encode_values(row.values)
                 writer.writerow(record)
+        
         # Load CSV file using Mimirs loadCSV method.
         table_name = mimir.loadDataSource(tmp_file, True, True, human_readable_name = human_readable_name, backend_options = backend_options, dependencies = dependencies)
-        os.remove(tmp_file)
+        #os.remove(tmp_file)
         sql = 'SELECT '+ colSql +' FROM '+table_name
         view_name, dependencies = mimir.createView(table_name, sql)
         # Get number of rows in the view that was created in the backend

--- a/vizier/datastore/mimir/store.py
+++ b/vizier/datastore/mimir/store.py
@@ -117,7 +117,7 @@ class MimirDatastore(DefaultDatastore):
         # Load CSV file using Mimirs loadCSV method.
         table_name = mimir.loadDataSource(tmp_file, True, True, human_readable_name = human_readable_name, backend_options = backend_options, dependencies = dependencies)
         os.remove(tmp_file)
-        sql = 'SELECT '+ colSql +' FROM {{input}};'
+        sql = 'SELECT '+ colSql +' FROM '+table_name
         view_name, dependencies = mimir.createView(table_name, sql)
         # Get number of rows in the view that was created in the backend
         row_count = mimir.countRows(view_name)
@@ -488,7 +488,7 @@ class MimirDatastore(DefaultDatastore):
                 colSql = colSql + ', ' + name_in_dataset + ' AS ' + name_in_rdb
             columns.append(col)
         # Create view for loaded dataset
-        sql = 'SELECT '+ colSql +' FROM {{input}};'
+        sql = 'SELECT '+ colSql +' FROM '+init_load_name
         view_name, dependencies = mimir.createView(init_load_name, sql)
         # TODO: this is a hack to speed up this step a bit.
         #  we get the first row id and the count and take a range;
@@ -584,7 +584,7 @@ class MimirDatastore(DefaultDatastore):
         # Depending on whether we need to update row ids we either query the
         # database or just get the schema. In either case mimir_schema will
         # contain a the returned Mimir schema information.
-        sql = base.get_select_query(table_name, columns=columns) + ';'
+        sql = base.get_select_query(table_name, columns=columns) 
         mimir_schema = mimir.getSchema(sql)
         
         # Create a mapping of column name (in database) to column type. This
@@ -664,6 +664,6 @@ def create_missing_key_view(dataset, lens_name, key_column):
     col_list = [stmt]
     for column in dataset.columns:
         col_list.append(column.name_in_rdb)
-    sql = 'SELECT ' + ','.join(col_list) + ' FROM ' + lens_name + ';'
+    sql = 'SELECT ' + ','.join(col_list) + ' FROM ' + lens_name 
     view_name, dependencies = mimir.createView(dataset.table_name, sql)
     return view_name, dataset.row_counter + len(case_conditions)

--- a/vizier/engine/packages/mimir/processor.py
+++ b/vizier/engine/packages/mimir/processor.py
@@ -204,24 +204,18 @@ class MimirProcessor(TaskProcessor):
         else:
             raise ValueError('unknown Mimir lens \'' + str(lens) + '\'')
         # Create Mimir lens
-        if command_id in [cmd.MIMIR_SCHEMA_MATCHING, cmd.MIMIR_TYPE_INFERENCE, cmd.MIMIR_SHAPE_DETECTOR]:
-            lens_name = mimir.createAdaptiveSchema(
-                mimir_table_name,
-                params,
-                command_id.upper()
-            )
-        else:
-            mimir_lens_response = mimir.createLens(
-                mimir_table_name,
-                params,
-                command_id.upper(),
-                arguments.get_value(cmd.PARA_MATERIALIZE_INPUT, default_value=True),
-                human_readable_name = ds_name.upper()
-            )
-            (lens_name, lens_annotations) = (
-                mimir_lens_response['lensName'],
-                None#mimir_lens_response['annotations']
-            )
+       
+        mimir_lens_response = mimir.createLens(
+            mimir_table_name,
+            params,
+            command_id.upper(),
+            arguments.get_value(cmd.PARA_MATERIALIZE_INPUT, default_value=True),
+            human_readable_name = ds_name.upper()
+        )
+        (lens_name, lens_annotations) = (
+            mimir_lens_response['lensName'],
+            None#mimir_lens_response['annotations']
+        )
         # Create a view including missing row ids for the result of a
         # MISSING KEY lens
         #if command_id == cmd.MIMIR_MISSING_KEY:

--- a/vizier/engine/packages/mimir/processor.py
+++ b/vizier/engine/packages/mimir/processor.py
@@ -87,11 +87,6 @@ class MimirProcessor(TaskProcessor):
             params = [column.name_in_rdb]
         elif command_id == cmd.MIMIR_GEOCODE:
             geocoder = arguments.get_value(cmd.PARA_GEOCODER)
-            params = ['GEOCODER(' + geocoder + ')']
-            add_column_parameter(params, 'HOUSE_NUMBER', dataset, arguments, cmd.PARA_HOUSE_NUMBER)
-            add_column_parameter(params, 'STREET', dataset, arguments, cmd.PARA_STREET)
-            add_column_parameter(params, 'CITY', dataset, arguments, cmd.PARA_CITY)
-            add_column_parameter(params, 'STATE', dataset, arguments, cmd.PARA_STATE)
             # Add columns for LATITUDE and LONGITUDE
             column_counter = dataset.max_column_id() + 1
             cname_lat = dataset.get_unique_name('LATITUDE')
@@ -110,7 +105,16 @@ class MimirProcessor(TaskProcessor):
                     data_type=DATATYPE_REAL
                 )
             )
-            params.append('RESULT_COLUMNS(' + cname_lat + ',' + cname_lon + ')')
+            params = {
+                'houseColumn': dataset.column_by_id(arguments.get_value(cmd.PARA_HOUSE_NUMBER, raise_error=False)).name_in_rdb,
+                'streetColumn': dataset.column_by_id(arguments.get_value(cmd.PARA_STREET, raise_error=False)).name_in_rdb,
+                'cityColumn': dataset.column_by_id(arguments.get_value(cmd.PARA_CITY, raise_error=False)).name_in_rdb,
+                'stateColumn': dataset.column_by_id(arguments.get_value(cmd.PARA_STATE, raise_error=False)).name_in_rdb,
+                'geocoder': geocoder#,
+                #'latitudeColumn': Option[String],
+                #'longitudeColumn': Option[String],
+                #'cacheCode': Option[String]
+            }
         elif command_id == cmd.MIMIR_KEY_REPAIR:
             column = dataset.column_by_id(arguments.get_value(pckg.PARA_COLUMN))
             params = [column.name_in_rdb]

--- a/vizier/engine/packages/sql/processor.py
+++ b/vizier/engine/packages/sql/processor.py
@@ -77,7 +77,7 @@ class SQLTaskProcessor(TaskProcessor):
         # variables
         source = args.get_value(cmd.PARA_SQL_SOURCE)
         if not source.endswith(';'):
-            source = source + ';'
+            source = source 
         ds_name = args.get_value(cmd.PARA_OUTPUT_DATASET, raise_error=False)
         # Get mapping of datasets in the context to their respective table
         # name in the Mimir backend

--- a/vizier/engine/packages/vizual/api/mimir.py
+++ b/vizier/engine/packages/vizual/api/mimir.py
@@ -67,7 +67,7 @@ class MimirVizualApi(VizualApi):
         col_list = []
         for col in schema:
             col_list.append(col.name_in_rdb)
-        sql = 'SELECT ' + ','.join(col_list) + ' FROM ' + dataset.table_name 
+        sql = 'SELECT ' + ','.join(['`' + col + '`' for col in col_list ]) + ' FROM ' + dataset.table_name 
         view_name, dependencies = mimir.createView(dataset.table_name, sql)
         # Store updated dataset information with new identifier
         ds = datastore.register_dataset(
@@ -106,7 +106,7 @@ class MimirVizualApi(VizualApi):
         col_list = []
         for col in dataset.columns:
             col_list.append(col.name_in_rdb)
-        sql = 'SELECT ' + ','.join(col_list) + ' FROM ' + dataset.table_name
+        sql = 'SELECT ' + ','.join(['`' + col + '`' for col in col_list ]) + ' FROM ' + dataset.table_name
         sql += ' WHERE ' + ROW_ID + ' <> ' + MIMIR_ROWID_COL.to_sql_value(roid) 
         view_name, dependencies = mimir.createView(dataset.table_name, sql)
         # Store updated dataset information with new identifier
@@ -165,7 +165,7 @@ class MimirVizualApi(VizualApi):
             else:
                 schema.append(col)
             col_list.append(col.name_in_rdb)
-        sql = 'SELECT ' + ','.join(col_list) + ' FROM ' + dataset.table_name 
+        sql = 'SELECT ' + ','.join(['`' + col + '`' for col in col_list ]) + ' FROM ' + dataset.table_name 
         view_name, dependencies = mimir.createView(dataset.table_name, sql)
         # Store updated dataset information with new identifier
         ds = datastore.register_dataset(
@@ -227,7 +227,7 @@ class MimirVizualApi(VizualApi):
                 col_list.append(" CAST('' AS int) AS " + col.name_in_rdb) 
             else:
                 col_list.append(col.name_in_rdb)
-        sql = 'SELECT ' + ','.join(col_list) + ' FROM ' + dataset.table_name 
+        sql = 'SELECT ' + ','.join(['`' + col + '`' for col in col_list ]) + ' FROM ' + dataset.table_name 
         view_name, dependencies = mimir.createView(dataset.table_name, sql)
         # Store updated dataset information with new identifier
         ds = datastore.register_dataset(
@@ -271,7 +271,7 @@ class MimirVizualApi(VizualApi):
         col_list = []
         for col in dataset.columns:
             col_list.append(col.name_in_rdb)
-        sql = 'SELECT ' + ','.join(col_list) + ' FROM ' + dataset.table_name
+        sql = 'SELECT ' + ','.join(['`' + col + '`' for col in col_list ]) + ' FROM ' + dataset.table_name
         mimirSchema = mimir.getSchema(sql)
         union_list = []
         for col in mimirSchema[1:]:
@@ -409,7 +409,7 @@ class MimirVizualApi(VizualApi):
         -------
         vizier.engine.packages.vizual.api.VizualApiResult
         """
-        source = "SELECT {};".format(", ".join(
+        source = "SELECT {}".format(", ".join(
                         default_val + " AS " + col_name
                         for default_val, col_name in initial_columns
                     ))
@@ -426,7 +426,7 @@ class MimirVizualApi(VizualApi):
             for col_defn, col_id in zip(initial_columns, range(len(initial_columns)))
         ]
 
-        ds = context.datastore.register_dataset(
+        ds = datastore.register_dataset(
             table_name=view_name,
             columns=columns,
             row_counter=1
@@ -625,11 +625,11 @@ class MimirVizualApi(VizualApi):
                 if idx == 0:
                     colSql = name_in_dataset + ' AS ' + name_in_rdb
                 elif idx == colIndex:
-                    colSql = colSql + ', ' + name_in_dataset + ' AS ' + name
+                    colSql = colSql + ', `' + name_in_dataset + '` AS `' + name + '`'
                     col.name = name
                     col.name_in_rdb = name
                 else:
-                    colSql = colSql + ', ' + name_in_dataset + ' AS ' + name_in_rdb
+                    colSql = colSql + ', `' + name_in_dataset + '` AS `' + name_in_rdb + '`'
                 columns.append(col)
                 idx = idx + 1
             # Create view for loaded dataset
@@ -749,7 +749,7 @@ class MimirVizualApi(VizualApi):
                 col_list.append(stmt)
             else:
                 col_list.append(col.name_in_rdb)
-        sql = 'SELECT ' + ','.join(col_list) + ' FROM ' + dataset.table_name 
+        sql = 'SELECT ' + ','.join(['`' + col + '`' for col in col_list ]) + ' FROM ' + dataset.table_name 
         view_name, dependencies = mimir.createView(dataset.table_name, sql)
         # Store updated dataset information with new identifier
         ds = datastore.register_dataset(

--- a/vizier/engine/packages/vizual/api/mimir.py
+++ b/vizier/engine/packages/vizual/api/mimir.py
@@ -67,7 +67,7 @@ class MimirVizualApi(VizualApi):
         col_list = []
         for col in schema:
             col_list.append(col.name_in_rdb)
-        sql = 'SELECT ' + ','.join(col_list) + ' FROM ' + dataset.table_name + ';'
+        sql = 'SELECT ' + ','.join(col_list) + ' FROM ' + dataset.table_name 
         view_name, dependencies = mimir.createView(dataset.table_name, sql)
         # Store updated dataset information with new identifier
         ds = datastore.register_dataset(
@@ -107,7 +107,7 @@ class MimirVizualApi(VizualApi):
         for col in dataset.columns:
             col_list.append(col.name_in_rdb)
         sql = 'SELECT ' + ','.join(col_list) + ' FROM ' + dataset.table_name
-        sql += ' WHERE ' + ROW_ID + ' <> ' + MIMIR_ROWID_COL.to_sql_value(roid) + ';'
+        sql += ' WHERE ' + ROW_ID + ' <> ' + MIMIR_ROWID_COL.to_sql_value(roid) 
         view_name, dependencies = mimir.createView(dataset.table_name, sql)
         # Store updated dataset information with new identifier
         ds = datastore.register_dataset(
@@ -165,7 +165,7 @@ class MimirVizualApi(VizualApi):
             else:
                 schema.append(col)
             col_list.append(col.name_in_rdb)
-        sql = 'SELECT ' + ','.join(col_list) + ' FROM ' + dataset.table_name + ';'
+        sql = 'SELECT ' + ','.join(col_list) + ' FROM ' + dataset.table_name 
         view_name, dependencies = mimir.createView(dataset.table_name, sql)
         # Store updated dataset information with new identifier
         ds = datastore.register_dataset(
@@ -227,7 +227,7 @@ class MimirVizualApi(VizualApi):
                 col_list.append(" CAST('' AS int) AS " + col.name_in_rdb) 
             else:
                 col_list.append(col.name_in_rdb)
-        sql = 'SELECT ' + ','.join(col_list) + ' FROM ' + dataset.table_name + ';'
+        sql = 'SELECT ' + ','.join(col_list) + ' FROM ' + dataset.table_name 
         view_name, dependencies = mimir.createView(dataset.table_name, sql)
         # Store updated dataset information with new identifier
         ds = datastore.register_dataset(
@@ -633,7 +633,7 @@ class MimirVizualApi(VizualApi):
                 columns.append(col)
                 idx = idx + 1
             # Create view for loaded dataset
-            sql = 'SELECT '+ colSql +' FROM {{input}};'
+            sql = 'SELECT '+ colSql +' FROM '+dataset.table_name
             view_name, dependencies = mimir.createView(dataset.table_name, sql)
             # There are no changes to the underlying database. We only need to
             # change the column information in the dataset schema.
@@ -689,8 +689,8 @@ class MimirVizualApi(VizualApi):
             if reversed[i]:
                 stmt += ' DESC'
             order_by_clause.append(stmt)
-        sql = 'SELECT * FROM {{input}} ORDER BY '
-        sql += ','.join(order_by_clause) + ';'
+        sql = 'SELECT * FROM '+dataset.table_name+' ORDER BY '
+        sql += ','.join(order_by_clause) 
         view_name, dependencies = mimir.createView(dataset.table_name, sql)
         
         # Register new dataset with only a modified list of row identifier
@@ -741,7 +741,7 @@ class MimirVizualApi(VizualApi):
                     val_stmt = col.to_sql_value(value)
                     col_sql = val_stmt + ' ELSE ' + col.name_in_rdb + ' END '
                 except ValueError:
-                    col_sql = '\'' + str(value) + '\' ELSE CAST({{input}}.' + col.name_in_rdb  + ' AS varchar) END '
+                    col_sql = '\'' + str(value) + '\' ELSE CAST('+dataset.table_name+'.' + col.name_in_rdb  + ' AS varchar) END '
                 rid_sql = MIMIR_ROWID_COL.to_sql_value(row_id)
                 stmt = 'CASE WHEN ' + ROW_ID + ' = ' + rid_sql + ' THEN '
                 stmt += col_sql
@@ -749,7 +749,7 @@ class MimirVizualApi(VizualApi):
                 col_list.append(stmt)
             else:
                 col_list.append(col.name_in_rdb)
-        sql = 'SELECT ' + ','.join(col_list) + ' FROM ' + dataset.table_name + ';'
+        sql = 'SELECT ' + ','.join(col_list) + ' FROM ' + dataset.table_name 
         view_name, dependencies = mimir.createView(dataset.table_name, sql)
         # Store updated dataset information with new identifier
         ds = datastore.register_dataset(

--- a/vizier/engine/packages/vizual/api/mimir.py
+++ b/vizier/engine/packages/vizual/api/mimir.py
@@ -78,7 +78,7 @@ class MimirVizualApi(VizualApi):
         )
         return VizualApiResult(ds)
 
-    def delete_row(self, identifier, rowid, datastore):
+    def delete_row(self, identifier, row_index, datastore):
         """Delete a row in a given dataset.
 
         Raises ValueError if no dataset with given identifier exists or if the
@@ -107,7 +107,7 @@ class MimirVizualApi(VizualApi):
         for col in dataset.columns:
             col_list.append(col.name_in_rdb)
         sql = 'SELECT ' + ','.join(['`' + col + '`' for col in col_list ]) + ' FROM ' + dataset.table_name
-        sql += ' WHERE ' + ROW_ID + ' <> ' + MIMIR_ROWID_COL.to_sql_value(roid) 
+        sql += ' WHERE ' + ROW_ID + ' <> ' + MIMIR_ROWID_COL.to_sql_value(row_index) 
         view_name, dependencies = mimir.createView(dataset.table_name, sql)
         # Store updated dataset information with new identifier
         ds = datastore.register_dataset(

--- a/vizier/engine/packages/vizual/processor.py
+++ b/vizier/engine/packages/vizual/processor.py
@@ -210,13 +210,13 @@ class VizualTaskProcessor(TaskProcessor):
         """
         # Get dataset name and and row index.
         ds_name = args.get_value(pckg.PARA_DATASET).lower()
-        row_index = args.get_value(cmd.PARA_ROW)
+        row = args.get_value(cmd.PARA_ROW)
         #  Get dataset. Raises exception if the dataset does not exist.
         ds = context.get_dataset(ds_name)
         # Execute delete row command
         result = self.api.delete_row(
             identifier=ds.identifier,
-            row_index=row_index,
+            row_index=row,
             datastore=context.datastore
         )
         # Create result object

--- a/vizier/mimir.py
+++ b/vizier/mimir.py
@@ -61,12 +61,17 @@ def createLens(dataset, params, type, materialize, human_readable_name = None):
     return resp
 
 def createView(dataset, query):
+    depts = None
+    if isinstance(dataset, dict):
+        depts = dataset
+    else:
+        depts = {dataset:dataset}
     req_json = {
-      "input": dataset,
+      "input": depts,
       "query": query
     }
     resp = readResponse(requests.post(_mimir_url + 'view/create', json=req_json))
-    return (resp['viewName'], resp['dependencies'])
+    return (resp['viewName'], []) #resp['dependencies'])
 
 def createAdaptiveSchema(dataset, params, type):
     req_json = {
@@ -158,7 +163,7 @@ def vistrailsQueryMimirJson(query, include_uncertainty, include_reasons, input =
     return resp
 
 def countRows(view_name):
-    sql = 'SELECT COUNT(1) FROM ' + view_name + ';'
+    sql = 'SELECT COUNT(1) FROM ' + view_name 
     rs_count = vistrailsQueryMimirJson(sql, False, False)
     row_count = int(rs_count['data'][0][0])
     return row_count

--- a/vizier/viztrail/command.py
+++ b/vizier/viztrail/command.py
@@ -300,19 +300,22 @@ class ModuleArguments(object):
                     raise ValueError('missing value for parameter \'' + str(arg_id) + '\'')
             elif datatype == pckg.DT_BOOL:
                 if not isinstance(arg_value, bool):
-                    raise ValueError('expected bool for \'' + str(arg_id) + '\'')
+                    raise ValueError('expected bool for \'' + str(arg_id) + '\' (got \'' + str(arg_value) + '\')')
             elif datatype == pckg.DT_DECIMAL:
                 if not isinstance(arg_value, float):
-                    raise ValueError('expected float for \'' + str(arg_id) + '\'')
+                    raise ValueError('expected float for \'' + str(arg_id) + '\' (got \'' + str(arg_value) + '\')')
             elif datatype == pckg.DT_SCALAR:
                 if not is_scalar(arg_value):
-                    raise ValueError('expected scalar for \'' + str(arg_id) + '\'')
+                    raise ValueError('expected scalar for \'' + str(arg_id) + '\' (got \'' + str(arg_value) + '\')')
             elif datatype in pckg.INT_TYPES:
                 if not isinstance(arg_value, int):
-                    raise ValueError('expected int for \'' + str(arg_id) + '\'')
+                    raise ValueError('expected int for \'' + str(arg_id) + '\' (got \'' + str(arg_value) + '\')')
             elif datatype in pckg.STRING_TYPES:
-                if not isinstance(arg_value, str):
-                    raise ValueError('expected string for \'' + str(arg_id) + '\'')
+                # JSON stupidly makes number-like strings into numbers
+                if isinstance(arg_value, int) or isinstance(arg_value, float):
+                    self.arguments[arg_id] = str(arg_value)
+                elif not isinstance(arg_value, str):
+                    raise ValueError('expected string for \'' + str(arg_id) + '\' (got \'' + str(arg_value) + '\')')
             elif datatype == pckg.DT_FILE_ID:
                 # Expects a dictinary that contains at least a fileId or the
                 # an uri element
@@ -322,15 +325,15 @@ class ModuleArguments(object):
                     raise ValueError('invalid file identifier')
             elif datatype == pckg.DT_LIST:
                 if not isinstance(arg_value, list):
-                    raise ValueError('expected list for \'' + str(arg_id) + '\'')
+                    raise ValueError('expected list for \'' + str(arg_id) + '\' (got \'' + str(arg_value) + '\')')
                 for args in arg_value:
                     args.validate(parameters)
             elif datatype == pckg.DT_RECORD:
                 if not isinstance(arg_value, ModuleArguments):
-                    raise ValueError('expected list for \'' + str(arg_id) + '\'')
+                    raise ValueError('expected list for \'' + str(arg_id) + '\' (got \'' + str(arg_value) + '\')')
                 arg_value.validate(parameters)
             else:
-                raise RuntimeError('unknonw data type \'' + str(datatype) + '\'')
+                raise RuntimeError('unknown data type \'' + str(datatype) + '\' (got \'' + str(arg_value) + '\')')
             keys.add(arg_id)
         # Ensure that all mandatory arguments are given
         for key in required_key_values:

--- a/vizier/viztrail/module/output.py
+++ b/vizier/viztrail/module/output.py
@@ -25,6 +25,7 @@ import vizier.config.base as config
 from vizier.mimir import MimirError
 from requests.exceptions import ConnectionError
 import itertools
+from vizier import debug_is_on
 
 """Predefined output types."""
 OUTPUT_CHART = 'chart/view'
@@ -32,9 +33,6 @@ OUTPUT_TEXT = 'text/plain'
 OUTPUT_HTML = 'text/html'
 OUTPUT_MARKDOWN = 'text/markdown'
 OUTPUT_DATASET = 'dataset/view'
-
-def debug_is_on():
-    return str(os.environ.get('VIZIERSERVER_DEBUG', "False")) == "True"
 
 def format_stack_trace(ex):
     trace = traceback.extract_tb(ex.__traceback__, limit = 30)

--- a/vizier/viztrail/module/provenance.py
+++ b/vizier/viztrail/module/provenance.py
@@ -161,7 +161,7 @@ class ModuleProvenance(object):
             if self.write[name] is None:
                 debug("DEPENDENT / WRITE FAILED")
                 return True
-            elif name in datasets:
+            elif name in datasets and name not in self.read:
                 debug("DEPENDENT / OVERWRITE")
                 return True
         # Check if all read dependencies are present and have not been modified


### PR DESCRIPTION
A few QOL improvements and bugfixes, but the real change is that all Vizual operations now use the Mimir Vizual Script endpoint instead of trying to roll their own SQL.  This is necessary to address the lack of exposed ROWIDs (https://github.com/VizierDB/web-ui/issues/204)

This pull request depends on https://github.com/UBOdin/mimir-api/pull/1