### PR TITLE
Use the new /query/table Mimir API (closes https://github.com/VizierDB/web-ui/issues/221)

### DIFF
--- a/vizier/datastore/mimir/reader.py
+++ b/vizier/datastore/mimir/reader.py
@@ -106,15 +106,15 @@ class MimirDatasetReader(DatasetReader):
         if not self.is_open:
             # Query the database to get the list of rows. Sort rows according to
             # order in row_ids and return a InMemReader
-            sql = base.get_select_query(self.table_name, columns=self.columns)
-            if self.rowid != None:
-                sql += ' WHERE ROWID() = ' + str(self.rowid)
-            if self.is_range_query:
-                if self.limit > 0:
-                    sql +=  ' LIMIT ' + str(self.limit)
-                if self.offset > 0:
-                    sql += ' OFFSET ' + str(self.offset) 
-            rs = mimir.vistrailsQueryMimirJson(sql, True, False)
+            rs = mimir.getTable(
+                    table = self.table_name,
+                    columns = [col.name_in_rdb for col in self.columns],
+                    offset_to_rowid = self.rowid,
+                    limit = self.limit if self.is_range_query else None,
+                    offset = self.offset if self.is_range_query else None,
+                    include_uncertainty = True
+                )
+
             #self.row_ids = rs['prov']
             # Initialize mapping of column rdb names to index positions in
             # dataset rows

--- a/vizier/mimir.py
+++ b/vizier/mimir.py
@@ -173,6 +173,22 @@ def vistrailsQueryMimirJson(query, include_uncertainty, include_reasons, input =
     resp = readResponse(requests.post(_mimir_url + 'query/data', json=req_json))
     return resp
 
+def getTable(table, columns = None, offset = None, offset_to_rowid = None, limit = None, include_uncertainty = None): 
+    req_json = { "table" : table }
+    if columns is not None:
+      req_json["columns"] = columns
+    if offset is not None:
+      req_json["offset"] = offset
+    if offset_to_rowid is not None:
+      req_json["offset_to_rowid"] = offset_to_rowid
+    if limit is not None:
+      req_json["limit"] = limit
+    if include_uncertainty is not None:
+      req_json["includeUncertainty"] = include_uncertainty
+
+    resp = readResponse(requests.post(_mimir_url + 'query/table', json=req_json))
+    return resp
+
 def countRows(view_name):
     sql = 'SELECT COUNT(1) FROM ' + view_name 
     rs_count = vistrailsQueryMimirJson(sql, False, False)

--- a/vizier/mimir.py
+++ b/vizier/mimir.py
@@ -31,7 +31,8 @@ class MimirError(Exception):
 
 PASSTHROUGH_ERRORS = set([
   "java.sql.SQLException",
-  "org.apache.spark.sql.AnalysisException"
+  "org.apache.spark.sql.AnalysisException",
+  "org.mimirdb.api.FormattedError"
 ])
 
 def readResponse(resp):
@@ -52,7 +53,7 @@ def readResponse(resp):
             errorType = json_object.get("errorType", "Unknown")
             errorMessage = json_object.get("errorMessage", "Unknown")
             if errorType not in PASSTHROUGH_ERRORS:
-                errorMessage = "Internal Error [Mimir]: {}".format(errorMessage)
+                errorMessage = "Internal Error [Mimir]: {} / {}".format(errorType, errorMessage)
             json_object["errorType"] = errorType
             json_object["errorMessage"] = errorMessage
             raise MimirError(json_object)


### PR DESCRIPTION
(closes https://github.com/VizierDB/web-ui/issues/221)

SparkSQL doesn't support offset.  There's a hack based on Sequence number annotation that
we used to use in Mimir 1, but that's no longer present/needed in Mimir 2.

https://github.com/UBOdin/mimir-api/commit/bfb7236af6dd26ffc1daf2bd747379c79b809619 introduced the
/query/table endpoint in the Mimir API, which allows direct lookups to a table / view definition,
including paged access via offset/limit.  This push migrates the main Mimir datset accessors
(i.e., vizier.datastore.mimir.dataset) to this new table API.  As a side effect, this should
make the table lookups more resilient to naming issues in tables/columns, since we no longer have
to go through SQL and the associated challenges in escaping/capitalizing identifiers.