### PR TITLE
Enhancements to vizierdb.show() (closes https://github.com/VizierDB/web-ui/issues/244)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ sklearn
 numpy
 pandas
 geopandas
-bokeh
+bokeh==2.0.1
 shapely
 astor
 minio

--- a/vizier/engine/packages/pycell/client/base.py
+++ b/vizier/engine/packages/pycell/client/base.py
@@ -39,7 +39,10 @@ from minio.error import ResponseError
 from minio.select.options import SelectObjectOptions, InputSerialization,\
     CSVInput, OutputSerialization, CSVOutput, RequestProgress
 from minio.select.errors import SelectCRCValidationError
-
+from bokeh.models.layouts import LayoutDOM as BokehLayout
+from matplotlib.figure import Figure as MatplotlibFigure
+from matplotlib.axes import Axes as MatplotlibAxes
+from vizier.engine.packages.pycell.plugins import vizier_bokeh_render, vizier_matplotlib_render
         
     
 class VizierDBClient(object):
@@ -479,7 +482,7 @@ class VizierDBClient(object):
     def set_output_format(self, mime_type):
         self.output_format = mime_type
 
-    def show(self, value, mime_type = None):
+    def show(self, value, mime_type = None, force_to_string = True):
         if not issubclass(type(value), OutputObject):
             if mime_type is not None:
                 value = OutputObject(value = value, type = mime_type)
@@ -493,8 +496,21 @@ class VizierDBClient(object):
                                 limit=10
                             )
                 value = DatasetOutput(ds_handle)
+            elif issubclass(type(value), BokehLayout):
+                value = vizier_bokeh_render(value)
+                value = HtmlOutput(value = value)
+            elif issubclass(type(value), MatplotlibFigure):
+                value = HtmlOutput(value = vizier_matplotlib_render(value))
+            elif issubclass(type(value), MatplotlibAxes):
+                value = HtmlOutput(value = vizier_matplotlib_render(value.get_figure()))
             else:
-                value = TextOutput(value = value)
+                repr_html = getattr(value, "_repr_html_", None)
+                if repr_html is not None:
+                    value = HtmlOutput(str(repr_html()))
+                elif force_to_string:
+                    value = TextOutput(value = str(value))
+                else:
+                    return
         self.stdout.append(value)
 
     def show_html(self, value):

--- a/vizier/engine/packages/pycell/plugins.py
+++ b/vizier/engine/packages/pycell/plugins.py
@@ -20,6 +20,7 @@
 import json
 import re
 import random
+import io
 from bokeh.io import output_notebook
 from bokeh.io.notebook import install_notebook_hook
 from bokeh.embed import json_item, file_html
@@ -48,10 +49,7 @@ def vizier_bokeh_load(resources, verbose, hide_banner, load_timeout):
     # in doing anything specific here.
     pass
 
-def vizier_bokeh_show(obj, state, notebook_handle):
-    """Hook called by Bokeh when show() is called"""
-    # r = "bokeh_plot_"+str([ random.choice(range(0, 10)) for x in range(0, 20) ])
-    global target_client
+def vizier_bokeh_render(obj):
     plot_object_id = "bokeh_plot_{}".format(obj.id)
 
     # Generate and sanitize the plot content
@@ -66,6 +64,13 @@ def vizier_bokeh_show(obj, state, notebook_handle):
     # actually embeds the image.  Note the substitution of single-quotes
     # in the sanitization step above.
     html += (('<img src onError="Bokeh.embed.embed_item('+content+');"/>'))
+    return html
+
+def vizier_bokeh_show(obj, state, notebook_handle):
+    """Hook called by Bokeh when show() is called"""
+    # r = "bokeh_plot_"+str([ random.choice(range(0, 10)) for x in range(0, 20) ])
+    global target_client
+    html = vizier_bokeh_render(obj)
     if target_client is None:
         print(html)
     else:
@@ -77,3 +82,9 @@ def vizier_bokeh_app(app, state, notebook_url, **kwargs):
     raise
 
 install_notebook_hook('vizier', vizier_bokeh_load, vizier_bokeh_show, vizier_bokeh_app)
+
+def vizier_matplotlib_render(figure):
+    with io.BytesIO() as imgbytes:
+        figure.savefig(imgbytes, format="svg")
+        return imgbytes.getvalue().decode("utf-8")
+

--- a/vizier/engine/packages/pycell/processor.py
+++ b/vizier/engine/packages/pycell/processor.py
@@ -84,7 +84,7 @@ class PyCellTaskProcessor(TaskProcessor):
         #get
         objects = context.datastore.get_objects(obj_type=PYTHON_EXPORT_TYPE)
         dos = [object for objects in [objects.for_id(doid) for doid in [ value for key, value in context.dataobjects.items()]] for object in objects ]
-        inj_src = ''
+        inj_src = 'show = vizierdb.show\n'
         # Get Python script from user arguments.  It is the source for VizierDBClient
         cell_src = args.get_value(cmd.PYTHON_SOURCE)
         dataobjects = list()
@@ -93,6 +93,7 @@ class PyCellTaskProcessor(TaskProcessor):
             dataobjects.append([obj.key,obj.identifier])
         # Assemble the source to run in the interpreter 
         source = inj_src + cell_src
+        print(" --- Running ---\n{}".format(source))
         # Initialize the scope variables that are available to the executed
         # Python script. At this point this includes only the client to access
         # and manipulate datasets in the undelying datastore


### PR DESCRIPTION
- Locking in a specific Bokeh version for compatibility with web-ui
- `vizierdb.show()` now aliased as just `show()`
- `show()` now correctly interprets a bokeh plot (mitigates conflicts w/ native bokeh plots)
- `show()` now correctly interprets objects with a _repr_html_ method (https://github.com/VizierDB/web-ui/issues/244)
- `show()` now correctly interprets matplotlib figures or axes
- optional argument to show() to prevent fallback to stringification if the type being displayed is not known (e.g., this might allow us to implement a jupyter-like force show() of the last line of code
- factored out code for displaying a bokeh plot from code needed to inject displays into bokeh's native `show()` method