### PR TITLE
Workflow serialization now emits correct per-module artifact list 

### DIFF
--- a/vizier/api/serialize/module.py
+++ b/vizier/api/serialize/module.py
@@ -125,6 +125,8 @@ def MODULE_HANDLE(
         artifacts: Dict[str, ArtifactDescriptor] = dict()
         for precursor in actual_workflow.modules:
             artifacts = precursor.provenance.get_database_state(artifacts)
+            if precursor == module:
+                break
         datasets = list()
         other_artifacts = list()
         for artifact_name in artifacts:


### PR DESCRIPTION
(closes https://github.com/VizierDB/web-ui/issues/264)

When serializing workflows, the module entries include an artifact list (datasets, charts,
generic artifacts) defining the workflow state after the module's execution.  A typo
was causing this state to be generated as of the last module in the workflow.  It is now generated
correctly.