### PR TITLE
Making sure that dataset properties show up in serialized DatasetHandles

### DIFF
--- a/vizier/api/serialize/dataset.py
+++ b/vizier/api/serialize/dataset.py
@@ -120,6 +120,7 @@ def DATASET_DESCRIPTOR(
     -------
     dict
     """
+
     obj = {
         labels.ID: dataset.identifier,
         labels.COLUMNS: [DATASET_COLUMN(col) for col in dataset.columns]#,
@@ -130,7 +131,7 @@ def DATASET_DESCRIPTOR(
     elif not dataset.name is None:
         obj[labels.NAME] = dataset.name
     # Add self reference if the project and url factory are given
-    if not project is None and not urls is None:
+    if project is not None and urls is not None:
         project_id = project.identifier
         dataset_id = dataset.identifier
         dataset_url = urls.get_dataset(
@@ -195,6 +196,7 @@ def DATASET_HANDLE(
     obj[labels.ROWS] = serialized_rows
     obj[labels.ROWCOUNT] = dataset.row_count
     obj[labels.OFFSET] = offset
+    obj[labels.PROPERTIES] = dataset.get_properties()
     # Add pagination references
     links = obj[labels.LINKS]
     # Max. number of records shown

--- a/vizier/api/webservice/server.py
+++ b/vizier/api/webservice/server.py
@@ -401,7 +401,7 @@ def get_branch_head(project_id, branch_id):
     # Get the workflow handle. The result is None if the project, branch or
     # workflow do not exist.
     workflow = api.workflows.get_workflow(project_id=project_id, branch_id=branch_id)
-    if not workflow is None:
+    if workflow is not None:
         return jsonify(workflow)
     raise srv.ResourceNotFound('unknown project \'' + project_id + '\' or branch \'' + branch_id + '\'')
 

--- a/vizier/api/webservice/workflow.py
+++ b/vizier/api/webservice/workflow.py
@@ -225,7 +225,7 @@ class VizierWorkflowApi(object):
                 workflow = branch.head
             else:
                 workflow = branch.get_workflow(workflow_id)
-            if not workflow is None:
+            if workflow is not None:
                 return serialwf.WORKFLOW_HANDLE(
                     project=project,
                     branch=branch,

--- a/vizier/datastore/mimir/dataset.py
+++ b/vizier/datastore/mimir/dataset.py
@@ -267,7 +267,10 @@ class MimirDatasetHandle(DatasetHandle):
 
     def get_row_count(self) -> int:
         if self._row_count is None:
-            self._row_count = mimir.countRows(self.identifier)
+            # try to use the count property if present
+            self._row_count = self.get_properties().get("count", None)
+            if self._row_count is None:
+                self._row_count = mimir.countRows(self.identifier)
         return self._row_count
 
     def get_properties(self) -> Dict[str, Any]:

--- a/vizier/mimir.py
+++ b/vizier/mimir.py
@@ -265,7 +265,7 @@ def getTable(
       offset: Optional[int] = None, 
       offset_to_rowid: Optional[str] = None, 
       limit: Optional[int] = None, 
-      include_uncertainty: Optional[bool] = None): 
+      include_uncertainty: Optional[bool] = None) -> Dict[str, Any]: 
     req_json: Dict[str, Any] = { "table" : table }
     if columns is not None:
       req_json["columns"] = columns
@@ -314,6 +314,7 @@ def getTableInfo(table: str) -> Tuple[List[Dict[str,str]], Dict[str, Any]]:
       "table": table
     }
     resp = readResponse(requests.post(_mimir_url + 'tableInfo', json=req_json))
+    # print("TABLEINFO: {}".format(resp))
     return (
       cast(List[Dict[str,str]], resp['schema']), 
       cast(Dict[str,Any], resp['properties'])


### PR DESCRIPTION
(re https://github.com/VizierDB/web-ui/issues/236 )
(re https://github.com/VizierDB/web-ui/issues/237 )

Also:
 - cleaning up a few more `not X is None`
 - if the count property is provided, Vizier will no longer go back to Mimir for a count when requested