### PR TITLE
Adding support for a workflow sql endpoint for use in support tools

### DIFF
--- a/vizier/api/webservice/server.py
+++ b/vizier/api/webservice/server.py
@@ -267,7 +267,6 @@ def update_project(project_id):
         raise srv.InvalidRequest(str(ex))
     raise srv.ResourceNotFound('unknown project \'' + project_id + '\'')
 
-
 # ------------------------------------------------------------------------------
 # Branches
 # ------------------------------------------------------------------------------
@@ -580,6 +579,21 @@ def replace_workflow_module(project_id, branch_id, module_id):
         raise srv.InvalidRequest(str(ex))
     raise srv.ResourceNotFound('unknown project \'' + project_id + '\' branch \'' + branch_id + '\' or module \'' + module_id + '\'')
 
+@bp.route('/projects/<string:project_id>/branches/<string:branch_id>/head/sql', methods=['GET', 'POST'])
+def query_workflow_head(project_id, branch_id):
+    """Pose a SQL query against the datasets at the current workflow head
+    
+    Request
+    -------
+    GET: ?query=... 
+    POST: [sql query in the data]
+    """
+
+    query = request.args.get('query', None)
+    if query is None: 
+        query = request.data.decode()
+    result = api.workflows.query_workflow(query, project_id, branch_id)
+    return result
 
 # ------------------------------------------------------------------------------
 # Tasks

--- a/vizier/datastore/base.py
+++ b/vizier/datastore/base.py
@@ -224,6 +224,16 @@ class Datastore(object):
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def query(self, 
+        query: str,
+        datasets: Dict[str, DatasetDescriptor]
+    ) -> Dict[str, Any]:
+        """Pose a raw SQL query against the specified datasets.
+        Doesn't actually change the data, just queries it.
+        """
+        raise NotImplementedError
+
 
 class DefaultDatastore(Datastore):
     """Implementation of Vizier data store. Uses the file system to maintain

--- a/vizier/datastore/fs/base.py
+++ b/vizier/datastore/fs/base.py
@@ -389,6 +389,17 @@ class FileSystemDatastore(DefaultDatastore):
         from vizier.datastore.mimir.store import DATA_OBJECT_FILE
         return os.path.join(self.get_dataobject_dir(identifier), DATA_OBJECT_FILE)
 
+    def query(self, 
+        query: str,
+        datasets: Dict[str, DatasetDescriptor]
+    ) -> Dict[str, Any]:
+        """Pose a raw SQL query against the specified datasets.
+        Doesn't actually change the data, just queries it.
+
+        Not supported by FS
+        """
+        raise NotImplementedError
+
 # ------------------------------------------------------------------------------
 # Helper Methods
 # ------------------------------------------------------------------------------

--- a/vizier/datastore/mimir/store.py
+++ b/vizier/datastore/mimir/store.py
@@ -24,7 +24,7 @@ from typing import List, Dict, Any, Optional, Tuple
 from vizier.core.util import get_unique_identifier
 from vizier.filestore.base import FileHandle
 from vizier.datastore.base import DefaultDatastore
-from vizier.datastore.dataset import DatasetRow, DatasetColumn
+from vizier.datastore.dataset import DatasetRow, DatasetColumn, DatasetDescriptor
 from vizier.datastore.annotation.base import DatasetCaveat
 from vizier.datastore.mimir.dataset import MimirDatasetColumn, MimirDatasetHandle
 
@@ -378,3 +378,19 @@ class MimirDatastore(DefaultDatastore):
             write_metadata_file(file_dir,f_handle)
         return file_handles
         
+    def query(self, 
+        query: str,
+        datasets: Dict[str, DatasetDescriptor]
+    ) -> Dict[str, Any]:
+        """Pose a raw SQL query against the specified datasets.
+        Doesn't actually change the data, just queries it.
+        """
+        views = dict(
+            (view, datasets[view].identifier)
+            for view in datasets
+        )
+        result = mimir.sqlQuery(
+                        query = query, 
+                        views = views
+                )
+        return result

--- a/vizier/mimir.py
+++ b/vizier/mimir.py
@@ -249,20 +249,31 @@ def explainEverythingJson(query: str) -> List[DatasetCaveat]:
       for caveat in resp['reasons']
     ]
 
+def sqlQuery(
+      query: str, 
+      include_uncertainty: bool = True, 
+      views: Optional[Dict[str, str]] = None
+    ) -> Dict[str, Any]: 
+    req_json = {
+      "query": query,
+      "includeUncertainty": include_uncertainty,
+    } 
+    if views is not None:
+      req_json['views'] = views
+    resp = readResponse(requests.post(_mimir_url + 'query/data', json=req_json))
+    return resp
+
 def vistrailsQueryMimirJson(
       query: str, 
       include_uncertainty: bool, 
       include_reasons: bool, 
-      input: str = ''
+      input: str = '',
+      views: Optional[Dict[str, str]] = None
     ) -> Dict[str, Any]: 
-    req_json = {
-      "input": input,
-      "query": query,
-      "includeUncertainty": include_uncertainty,
-      "includeReasons": include_reasons
-    } 
-    resp = readResponse(requests.post(_mimir_url + 'query/data', json=req_json))
-    return resp
+  return sqlQuery(
+    query = query, 
+    include_uncertainty = include_uncertainty, 
+  )
 
 def getTable(
       table: str, 

--- a/vizier/viztrail/workflow.py
+++ b/vizier/viztrail/workflow.py
@@ -21,12 +21,15 @@ Viztrails are collections of workflows (branches). A viztrail maintains not
 only the different workflows but also the history for each of them.
 """
 
-from typing import Optional, List
+from typing import cast, Optional, List, Dict
 from datetime import datetime
+
 
 from vizier.core.util import init_value
 from vizier.core.timestamp import get_current_time
 from vizier.viztrail.module.base import ModuleState, MODULE_SUCCESS, ModuleHandle
+from vizier.datastore.dataset import ArtifactDescriptor, DatasetDescriptor
+
 
 """Workflow modification action identifier."""
 ACTION_APPEND = 'apd'
@@ -165,3 +168,32 @@ class WorkflowHandle(object):
             return self.modules[-1].is_active
         else:
             return False
+
+    @property
+    def tail_artifacts(self) -> Dict[str, ArtifactDescriptor]:
+        """Retrieve a list of dataset mappings at the tail of this
+        workflow.  
+
+        Returns a map from dataset name to dataset identifier.
+        """
+        datasets:Dict[str, ArtifactDescriptor] = dict()
+        for m in self.modules:
+            for artifact_name in m.provenance.write:
+                artifact = m.provenance.write[artifact_name]
+                datasets[artifact_name] = artifact
+        return datasets
+
+    @property
+    def tail_datasets(self) -> Dict[str, DatasetDescriptor]:
+        """Retrieve a list of dataset mappings at the tail of this
+        workflow.  
+
+        Returns a map from dataset name to dataset identifier.
+        """
+        datasets:Dict[str, DatasetDescriptor] = dict()
+        for m in self.modules:
+            for artifact_name in m.provenance.write:
+                artifact = m.provenance.write[artifact_name]
+                if artifact.is_dataset:
+                    datasets[artifact_name] = cast(DatasetDescriptor, artifact)
+        return datasets


### PR DESCRIPTION
This PR adds support for a new endpoint
  /projects/<string:project_id>/branches/<string:branch_id>/head/sql
The endpoint takes a single parameter that may be passed unescaped in the request body or by the `query` GET argument.  Both GET and POST methods are valid.

With the Mimir backend, this endpoint now allows running SQL queries against the datasets at the end of a workflow.  The primary immediate use is to allow Vizier to act as the datasource for a data visualization tool that we're building.

DEPENDS ON: https://github.com/UBOdin/mimir-api/pull/23