### PR TITLE
Fix line numbering in python error messages

### DIFF
--- a/vizier/datastore/base.py
+++ b/vizier/datastore/base.py
@@ -33,6 +33,10 @@ METADATA_FILE = 'annotations.json'
 
 
 class Datastore(object):
+
+    def __init__(self):
+        self.base_path: Optional[str] = None
+
     """Abstract API to store and retireve datasets."""
     @abstractmethod
     def create_dataset(self, 

--- a/vizier/engine/packages/pycell/processor.py
+++ b/vizier/engine/packages/pycell/processor.py
@@ -16,17 +16,21 @@
 
 """Implementation of the task processor for the Python cell package."""
 
+from typing import cast, List, Tuple, TextIO, Any, Dict
 import sys
 import requests
 import os
 
+from vizier.engine.task.base import TaskContext
 from vizier.engine.task.processor import ExecResult, TaskProcessor
 from vizier.engine.packages.pycell.client.base import VizierDBClient
 from vizier.engine.packages.pycell.plugins import python_cell_preload
 from vizier.engine.packages.stream import OutputStream
+from vizier.viztrail.command import ModuleArguments
 from vizier.viztrail.module.output import ModuleOutputs, OutputObject, TextOutput, OUTPUT_TEXT
 from vizier.viztrail.module.provenance import ModuleProvenance
 from vizier.datastore.artifact import ArtifactDescriptor, ARTIFACT_TYPE_PYTHON
+
 
 import vizier.engine.packages.pycell.base as cmd
 
@@ -62,7 +66,10 @@ class PyCellTaskProcessor(TaskProcessor):
         else:
             raise ValueError('unknown pycell command \'' + str(command_id) + '\'')
 
-    def execute_script(self, args, context):
+    def execute_script(self, 
+            args: ModuleArguments, 
+            context: TaskContext
+        ) -> ExecResult:
         """Execute a Python script in the given context.
 
         Parameters
@@ -80,17 +87,33 @@ class PyCellTaskProcessor(TaskProcessor):
         cell_src = args.get_value(cmd.PYTHON_SOURCE)
 
         # prepend python objects exported in previous cells to the source
-        injected_source = "\n".join(
+        exported_methods = [
             context.datastore.get_object(descriptor.identifier).decode()
             for name, descriptor in context.dataobjects.items()
             if descriptor.artifact_type == ARTIFACT_TYPE_PYTHON
-        )
+        ]
+        overrides = [
+            "def show(x):",
+            "  global vizierdb",
+            "  vizierdb.show(x)",
+            "def export(x):", 
+            "  global vizierdb",
+            "  vizierdb.export_module(x)",
+            "pass"
+        ]
+
+        injected_source = "\n".join(exported_methods + overrides)
+        injected_lines = len([x for x in injected_source if x == '\n'])+1
+
         source = injected_source + '\n' + cell_src
 
         # Initialize the scope variables that are available to the executed
         # Python script. At this point this includes only the client to access
         # and manipulate datasets in the undelying datastore
-        client = VizierDBClient(
+        #
+        # Use "any" type, since there's a (probably unnecessary) hack down
+        # below that creates something that pretends to be a client.
+        client: Any = VizierDBClient(
             datastore=context.datastore,
             datasets=context.datasets,
             source=cell_src,
@@ -102,12 +125,12 @@ class PyCellTaskProcessor(TaskProcessor):
         # Redirect standard output and standard error streams
         out = sys.stdout
         err = sys.stderr
-        stream = list()
-        sys.stdout = OutputStream(tag='out', stream=stream)
-        sys.stderr = OutputStream(tag='err', stream=stream)
+        stream: List[Tuple[str, str]] = list()
+        sys.stdout = cast(TextIO, OutputStream(tag='out', stream=stream))
+        sys.stderr = cast(TextIO, OutputStream(tag='err', stream=stream))
         # Keep track of exception that is thrown by the code
         exception = None
-        resdata = None
+        resdata: Dict[str, Any] = dict()
         # Run the Python code
         try:
             python_cell_preload(variables, client = client)
@@ -132,11 +155,12 @@ class PyCellTaskProcessor(TaskProcessor):
                 client.setattr('stdout',
                     [
                         OutputObject(type = item['type'], value = item['value'])
-                        for item in resdata.fetch('explicit_stdout', [])
+                        for item in resdata.get('explicit_stdout', [])
                     ])
                 
             else:
                 exec(source, variables, variables)
+
         except Exception as ex:
             exception = ex
         finally:
@@ -180,7 +204,7 @@ class PyCellTaskProcessor(TaskProcessor):
                     if not isinstance(read[name], str):
                         raise RuntimeError('invalid element in read mapping dictionary: {} (expecting str)'.format(read[name]))
                 else:
-                    read[name] = None
+                    raise RuntimeError('Unknown read artifact {}'.format(name))
             write = dict()
             for name in client.write:
                 if not isinstance(name, str):
@@ -201,7 +225,7 @@ class PyCellTaskProcessor(TaskProcessor):
                     else:
                         write[name] = write_descriptor
                 else:
-                    write[name] = None
+                    raise RuntimeError('Unknown write artifact {}'.format(name))
             print("Pycell Execution Finished")
             print("     read: {}".format(read))
             print("     write: {}".format(write))
@@ -212,7 +236,8 @@ class PyCellTaskProcessor(TaskProcessor):
             )
         else:
             print("ERROR: {}".format(exception))
-            outputs.error(exception)
+            assert(exception is not None)
+            outputs.error(exception, offset_lines = -injected_lines)
             provenance = ModuleProvenance()
         # Return execution result
         return ExecResult(


### PR DESCRIPTION
 (closes https://github.com/VizierDB/web-ui/issues/283)

The python processor prefixes code sent to the python interpreter with some additional cruft like code exported by previous modules.  These additional lines were throwing off error reporting in python cells, which would use the overall "<string>" blob passed to exec().

The most elegant way to fix this would have been to provide some hints to python about line number "zero" being midway through the file, but in a quick skim it didn't seem like this was possible.  Instead, there's now a fixed "offset" that gets added to the reported line number, computed based on the number of lines in the prefixed cell.

This PR also adds type annotations to the python cell processor and aliases `vizierdb.show` and `vizierdb.export_module` to `show` and `export` respectively.