### PR TITLE
add get_dataset_frame to datastore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ bokeh==2.0.1
 shapely
 astor
 minio
+pyarrow

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,8 @@ setup(
         'bokeh',
         'shapely',
         'astor',
-        'minio'
+        'minio',
+        'pyarrow'
     ],
     include_package_data=True,
     data_files=data_files,

--- a/vizier/datastore/base.py
+++ b/vizier/datastore/base.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from bokeh.util.sampledata import DataFrame
 
 """Vizier DB - Database - Collection of objects and methods to maintain and
 manipulate different versions of datasets that are manipulated by data curation
@@ -26,7 +27,7 @@ import os
 from vizier.filestore.base import FileHandle
 from vizier.datastore.annotation.base import DatasetCaveat
 from vizier.datastore.dataset import DatasetRow, DatasetColumn, DatasetDescriptor, DatasetHandle
-
+from pandas import DataFrame
 
 """Metadata file name for datasets in the the default datastore."""
 METADATA_FILE = 'annotations.json'
@@ -139,6 +140,22 @@ class Datastore(object):
         Returns
         -------
         vizier.datastore.base.DatasetHandle
+        """
+        raise NotImplementedError
+    
+    @abstractmethod
+    def get_dataset_frame(self, identifier: str, force_profiler: Optional[bool] = None) -> Optional[DataFrame]:
+        """Get a pandas DataFrame for the dataset with given identifier from the data
+        store. Returns None if no dataset with the given identifier exists.
+
+        Parameters
+        ----------
+        identifier : string
+            Unique dataset identifier
+
+        Returns
+        -------
+        pandas.DataFrame
         """
         raise NotImplementedError
 

--- a/vizier/datastore/fs/base.py
+++ b/vizier/datastore/fs/base.py
@@ -37,7 +37,7 @@ from vizier.datastore.fs.dataset import FileSystemDatasetHandle
 from vizier.datastore.reader import DefaultJsonDatasetReader
 from vizier.filestore.base import FileHandle, Filestore
 from vizier.filestore.base import get_download_filename
-
+from pandas import DataFrame
 
 """Constants for data file names."""
 DATA_FILE = 'data.json'
@@ -254,6 +254,9 @@ class FileSystemDatastore(DefaultDatastore):
             data_file=os.path.join(dataset_dir, DATA_FILE),
             properties_filename=self.get_properties_filename(identifier)
         )
+        
+    def get_dataset_frame(self, identifier: str, force_profiler: Optional[bool] = None) -> Optional[DataFrame]:
+        return None
 
     def load_dataset(self, 
             f_handle: FileHandle, 

--- a/vizier/engine/packages/pycell/client/base.py
+++ b/vizier/engine/packages/pycell/client/base.py
@@ -415,6 +415,33 @@ class VizierDBClient(object):
             existing_name = name.lower()
         )
         
+    def get_dataset_frame(self, name):
+        """Get dataset with given name as a pandas dataframe.
+
+        Raises ValueError if the specified dataset does not exist.
+
+        Parameters
+        ----------
+        name : string
+            Unique dataset name
+
+        Returns
+        -------
+        pandas.Dataframe
+        """
+        # Make sure to record access idependently of whether the dataset exists
+        # or not. Ignore read access to datasets that have been written.
+        if not name.lower() in self.write:
+            self.read.add(name.lower())
+        # Get identifier for the dataset with the given name. Will raise an
+        # exception if the name is unknown
+        identifier = self.get_dataset_identifier(name)
+        # Read dataset from datastore and return it.
+        dataset_frame = self.datastore.get_dataset_frame(identifier)
+        if dataset_frame is None:
+            raise ValueError('unknown dataset \'' + identifier + '\'')
+        return dataset_frame
+        
     def dataset_from_s3(self, 
         bucket: str, 
         folder: str, 

--- a/vizier/mimir.py
+++ b/vizier/mimir.py
@@ -279,6 +279,20 @@ def vistrailsQueryMimirJson(
     include_uncertainty = include_uncertainty, 
   )
 
+def getDataframe(
+      query: str, 
+      include_uncertainty: bool = True, 
+      views: Optional[Dict[str, str]] = None
+    ) -> Dict[str, Any]: 
+    req_json = {
+      "query": query,
+      "includeUncertainty": include_uncertainty,
+    } 
+    if views is not None:
+      req_json['views'] = views
+    resp = readResponse(requests.post(_mimir_url + 'query/dataframe', json=req_json))
+    return resp
+
 def getTable(
       table: str, 
       columns: Optional[List[str]] = None, 


### PR DESCRIPTION
Adds get_dataset_frame to datastore and an implementation of it to mimir datastore that calls the MimirAPI endpoint described by PR: https://github.com/UBOdin/mimir-api/pull/29 that takes a query and collects a dataframe and reads it in python using apache arrow and returns it as a pandas dataframe. This is the first step towards: VizierDB/web-ui#91 and VizierDB/web-ui#251 but also useful standing on it's own.