### PR TITLE
Fleshing out python UDFs and fixing type checking

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,5 @@ bokeh==2.0.1
 shapely
 astor
 minio
-pyarrow
+pyarrowdata-science-types
+pyspark

--- a/vizier/api/client/datastore/base.py
+++ b/vizier/api/client/datastore/base.py
@@ -19,7 +19,7 @@ datastore is for example used by python cell processors that do not have access
 to a shared file system, e.g., processors that are sandboxed in containers.
 """
 
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Tuple
 import json
 import requests
 
@@ -52,7 +52,10 @@ class DatastoreClient(Datastore):
     def create_dataset(self, 
             columns: List[DatasetColumn], 
             rows: List[DatasetRow], 
-            properties: Optional[Dict[str, Any]] =None
+            properties: Optional[Dict[str, Any]] = None,
+            human_readable_name: str = "Untitled Dataset", 
+            backend_options: Optional[List[Tuple[str, str]]] = None, 
+            dependencies: Optional[List[str]] = None
         ) -> DatasetDescriptor:
         """Create a new dataset in the project datastore using the API. Expects
         a list of columns and the rows for the dataset. All columns and rows

--- a/vizier/datastore/base.py
+++ b/vizier/datastore/base.py
@@ -42,7 +42,10 @@ class Datastore(object):
     def create_dataset(self, 
             columns: List[DatasetColumn], 
             rows: List[DatasetRow], 
-            properties: Dict[str, Any] = {}
+            properties: Optional[Dict[str, Any]] = None,
+            human_readable_name: str = "Untitled Dataset", 
+            backend_options: Optional[List[Tuple[str, str]]] = None, 
+            dependencies: Optional[List[str]] = None
         ) -> DatasetDescriptor:
         """Create a new dataset in the datastore. Expects at least the list of
         columns and the rows for the dataset.
@@ -110,7 +113,10 @@ class Datastore(object):
         raise NotImplementedError
     
     @abstractmethod
-    def get_object(self, identifier, expected_type=None):
+    def get_object(self, 
+            identifier: str, 
+            expected_type: Optional[str] = None
+        ) -> bytes:
         """Get an object (artifact) from the datastore
 
         Parameters
@@ -355,6 +361,7 @@ class DefaultDatastore(Datastore):
         -------
         string
         """
+        assert(self.base_path is not None)
         return os.path.join(self.base_path, identifier)
 
     def get_descriptor(self, identifier):

--- a/vizier/datastore/fs/base.py
+++ b/vizier/datastore/fs/base.py
@@ -64,10 +64,10 @@ class FileSystemDatastore(DefaultDatastore):
     def create_dataset(self, 
             columns: List[DatasetColumn], 
             rows: List[DatasetRow], 
-            properties: Dict[str, Any] = {}, 
+            properties: Optional[Dict[str, Any]] = None, 
             human_readable_name: str = "Untitled Dataset", 
-            backend_options: Optional[List[Dict[str, str]]] = None, 
-            dependencies: List[str] = []
+            backend_options: Optional[List[Tuple[str, str]]] = None, 
+            dependencies: Optional[List[str]] = None
         ) -> DatasetDescriptor:
         """Create a new dataset in the datastore. Expects at least the list of
         columns and the rows for the dataset.
@@ -95,6 +95,8 @@ class FileSystemDatastore(DefaultDatastore):
         # Validate (i) that each column has a unique identifier, (ii) each row
         # has a unique identifier, and (iii) that every row has exactly one
         # value per column.
+        properties = {} if properties is None else properties
+        dependencies = [] if dependencies is None else dependencies
         identifiers = set(
             int(row.identifier)
             for row in rows 

--- a/vizier/datastore/mimir/store.py
+++ b/vizier/datastore/mimir/store.py
@@ -66,10 +66,10 @@ class MimirDatastore(DefaultDatastore):
     def create_dataset(self, 
             columns: List[DatasetColumn], 
             rows: List[DatasetRow], 
-            properties: Dict[str, Any] = {},
-            human_readable_name: str = "Untitled Dataset", 
-            backend_options: List[Tuple[str, str]] = [], 
-            dependencies: List[str] = []
+            properties: Dict[str, Any] = None,
+            human_readable_name: str = "Untitled Dataset",
+            backend_options: Optional[List[Tuple[str, str]]] = None, 
+            dependencies: Optional[List[str]] = None
         ) -> MimirDatasetHandle:
         """Create a new dataset in the datastore. Expects at least the list of
         columns and the rows for the dataset.
@@ -89,6 +89,9 @@ class MimirDatastore(DefaultDatastore):
         vizier.datastore.dataset.DatasetDescriptor
         """
         # Get unique identifier for new dataset
+        properties = {} if properties is None else properties
+        backend_options = [] if backend_options is None else backend_options
+        dependencies = [] if dependencies is None else dependencies
         identifier = 'DS_' + get_unique_identifier()
         columns = [
             col if isinstance(col, MimirDatasetColumn) else MimirDatasetColumn(
@@ -147,9 +150,9 @@ class MimirDatastore(DefaultDatastore):
         return MimirDatasetHandle.from_mimir_result(identifier, schema, properties, name)
 
     def get_dataset_frame(self, identifier: str, force_profiler: Optional[bool] = None) -> Optional[DataFrame]:
-        import pyarrow as pa
-        from pyspark.rdd import _load_from_socket
-        from pyspark.sql.pandas.serializers import ArrowCollectSerializer
+        import pyarrow as pa #type: ignore
+        from pyspark.rdd import _load_from_socket #type: ignore
+        from pyspark.sql.pandas.serializers import ArrowCollectSerializer #type: ignore
         
         portSecret = mimir.getDataframe(query = 'SELECT * FROM {}'.format(identifier))
         results = list(_load_from_socket((portSecret['port'], portSecret['secret']), ArrowCollectSerializer()))

--- a/vizier/datastore/reader.py
+++ b/vizier/datastore/reader.py
@@ -25,7 +25,7 @@ import csv
 import gzip
 import json
 from io import TextIOWrapper
-from typing import List, Optional
+from typing import cast, List, Optional, IO
 
 from vizier.datastore.dataset import DatasetRow
 from vizier.datastore.base import DatasetColumn
@@ -311,7 +311,7 @@ class DefaultJsonDatasetReader(DatasetReader):
         """
         # Open file handle
         if self.compressed:
-            fh = gzip.open(self.filename, 'wb')
+            fh = cast(IO, gzip.open(self.filename, 'wb'))
         else:
             fh = open(self.filename, 'w')
 

--- a/vizier/engine/packages/pycell/plugins.py
+++ b/vizier/engine/packages/pycell/plugins.py
@@ -16,6 +16,10 @@
 
 """Extensions to preload prior to executing a python cell (e.g., visualization tools)"""
 
+from typing import TYPE_CHECKING, Dict, Any, Optional
+
+if TYPE_CHECKING:
+    from vizier.engine.packages.pycell.client.base import VizierDBClient
 
 import json
 import re
@@ -24,9 +28,10 @@ from bokeh.io import output_notebook # type: ignore[import]
 from bokeh.io.notebook import install_notebook_hook # type: ignore[import]
 from bokeh.embed import json_item # type: ignore[import]
 
-target_client = None
 
-def python_cell_preload(variables, client):
+target_client: Optional["VizierDBClient"] = None
+
+def python_cell_preload(variables: Dict[str, Any], client: "VizierDBClient"):
     global target_client
     """Convenient place to hook extension code that needs to run before a python cell"""
 

--- a/vizier/engine/packages/pycell/processor.py
+++ b/vizier/engine/packages/pycell/processor.py
@@ -100,6 +100,10 @@ class PyCellTaskProcessor(TaskProcessor):
             "def export(x):", 
             "  global vizierdb",
             "  vizierdb.export_module(x)",
+            "def return_type(dt):",
+            "  def wrap(x):",
+            "    return x",
+            "  return wrap",
             "pass"
         ]
 

--- a/vizier/engine/packages/stream.py
+++ b/vizier/engine/packages/stream.py
@@ -15,13 +15,13 @@
 # limitations under the License.
 
 """Class to redirect output streams during script execution."""
-
+from typing import List, Tuple
 
 class OutputStream(object):
     """Output stream for standard output and standard error streams when
     executing scripts in a notebook cell.
     """
-    def __init__(self, tag, stream):
+    def __init__(self, tag: str, stream: List[Tuple[str,str]]):
         self.closed = False
         self._tag = tag
         self._stream = stream

--- a/vizier/engine/packages/vizual/api/mimir.py
+++ b/vizier/engine/packages/vizual/api/mimir.py
@@ -699,7 +699,10 @@ class MimirVizualApi(VizualApi):
             order_by_clause.append(stmt)
         sql = 'SELECT * FROM '+dataset.identifier+' ORDER BY '
         sql += ','.join(order_by_clause) 
-        view_name, dependencies, schema, properties = mimir.createView(dataset.identifier, sql)
+        view_name, dependencies, schema, properties, functionDeps = mimir.createView(
+                datasets = { dataset.identifier : dataset.identifier }, 
+                query = sql
+            )
         ds = MimirDatasetHandle.from_mimir_result(view_name, schema, properties)
         return VizualApiResult(ds)
 

--- a/vizier/engine/packages/vizual/processor.py
+++ b/vizier/engine/packages/vizual/processor.py
@@ -20,7 +20,7 @@ import re
 
 from vizier.core.loader import ClassLoader
 from vizier.core.util import is_valid_name
-from vizier.datastore.dataset import DatasetDescriptor, ArtifactDescriptor
+from vizier.datastore.dataset import DatasetDescriptor
 from vizier.engine.task.processor import ExecResult, TaskProcessor
 from vizier.viztrail.module.output import ModuleOutputs, TextOutput, HtmlOutput, DatasetOutput, OutputObject
 from vizier.viztrail.module.provenance import ModuleProvenance
@@ -213,7 +213,6 @@ class VizualTaskProcessor(TaskProcessor):
             input_dataset=ds,
             output_dataset=result.dataset,
             stdout=['1 column deleted'],
-            database_state=context.datasets
         )
 
     def compute_delete_row(self, 
@@ -250,7 +249,6 @@ class VizualTaskProcessor(TaskProcessor):
             input_dataset=ds,
             output_dataset=result.dataset,
             stdout=['1 row deleted'],
-            database_state=context.datasets
         )
 
     def compute_drop_dataset(self, 
@@ -339,7 +337,6 @@ class VizualTaskProcessor(TaskProcessor):
             input_dataset=ds,
             output_dataset=result.dataset,
             stdout=[str(len(columns)) + ' column(s) filtered'],
-            database_state=context.datasets
         )
 
     def compute_insert_column(self, 
@@ -378,7 +375,6 @@ class VizualTaskProcessor(TaskProcessor):
             input_dataset=ds,
             output_dataset=result.dataset,
             stdout=['1 column inserted'],
-            database_state=context.datasets
         )
 
     def compute_insert_row(self, 
@@ -415,7 +411,6 @@ class VizualTaskProcessor(TaskProcessor):
             input_dataset=ds,
             output_dataset=result.dataset,
             stdout=['1 row inserted'],
-            database_state=context.datasets
         )
 
     def compute_load_dataset(self, 
@@ -760,7 +755,6 @@ class VizualTaskProcessor(TaskProcessor):
             input_dataset=ds,
             output_dataset=result.dataset,
             stdout=['1 column moved'],
-            database_state=context.datasets
         )
 
     def compute_move_row(self, 
@@ -799,7 +793,6 @@ class VizualTaskProcessor(TaskProcessor):
             input_dataset=ds,
             output_dataset=result.dataset,
             stdout=['1 row moved'],
-            database_state=context.datasets
         )
 
     def compute_rename_column(self, 
@@ -838,7 +831,6 @@ class VizualTaskProcessor(TaskProcessor):
             input_dataset=ds,
             output_dataset=result.dataset,
             stdout=['1 column renamed'],
-            database_state=context.datasets
         )
 
     def compute_rename_dataset(self, 
@@ -933,7 +925,6 @@ class VizualTaskProcessor(TaskProcessor):
             input_dataset=ds,
             output_dataset=result.dataset,
             stdout=['dataset sorted'],
-            database_state=context.datasets
         )
 
     def compute_update_cell(self, 
@@ -977,7 +968,6 @@ class VizualTaskProcessor(TaskProcessor):
             input_dataset=ds,
             output_dataset=result.dataset,
             stdout=['row(s) updated'],
-            database_state=context.datasets
         )
 
     def create_exec_result(
@@ -985,7 +975,6 @@ class VizualTaskProcessor(TaskProcessor):
         dataset_name: str, 
         input_dataset: Optional[DatasetDescriptor]=None, 
         output_dataset: Optional[DatasetDescriptor]=None,
-        database_state: Optional[Dict[str, ArtifactDescriptor]]=None, 
         stdout: Optional[List[str]]=None, 
         resources: Optional[Dict[str, Any]]=None
     ):
@@ -1003,9 +992,6 @@ class VizualTaskProcessor(TaskProcessor):
             Descriptor for the input dataset
         output_dataset: vizier.datastore.dataset.DatasetDescriptor, optional
             Descriptor for the resulting dataset
-        database_state: dict, optional
-            Identifier for datasets in the database state agains which a task
-            was executed (keyed by user-provided name)
         stdout= list(string), optional
             Lines in the command output
         resources: dict, optional

--- a/vizier/engine/task/base.py
+++ b/vizier/engine/task/base.py
@@ -19,14 +19,14 @@ in which task are executed. The interface for task execution engines (i.e.,
 processors) is defined in the processor module.
 """
 
-from typing import Optional, Dict, Any
+from typing import cast, Optional, Dict, Any
 
 
 from vizier.engine.controller import WorkflowController
 from vizier.datastore.base import Datastore
 from vizier.filestore.base import Filestore
 from vizier.datastore.artifact import ArtifactDescriptor
-from vizier.datastore.dataset import DatasetHandle
+from vizier.datastore.dataset import DatasetHandle, DatasetDescriptor
 
 class TaskContext(object):
     """The task context contains references to the datastore and filestore that
@@ -72,9 +72,17 @@ class TaskContext(object):
         self.project_id = project_id
         self.datastore = datastore
         self.filestore = filestore
-        self.datasets = { name: artifacts[name] for name in artifacts if artifacts[name].is_dataset }
+        self.datasets: Dict[str, DatasetDescriptor] = { 
+            name: cast(DatasetDescriptor, artifacts[name]) 
+            for name in artifacts 
+            if artifacts[name].is_dataset 
+        }
         self.resources = resources
-        self.dataobjects = { name: artifacts[name] for name in artifacts if not artifacts[name].is_dataset }
+        self.dataobjects: Dict[str, ArtifactDescriptor] = { 
+            name: artifacts[name] 
+            for name in artifacts 
+            if not artifacts[name].is_dataset 
+        }
 
     def get_dataset(self, 
             name: str

--- a/vizier/filestore/base.py
+++ b/vizier/filestore/base.py
@@ -17,7 +17,7 @@
 """Interface for file store to maintain files that are uploaded via the Web UI
 and need to keep as a local copy because they are not accessible via an Url.
 """
-from typing import Optional, IO, Dict, Any
+from typing import cast, Optional, IO, Dict, Any
 
 import gzip
 import mimetypes
@@ -127,7 +127,7 @@ class FileHandle(object):
         """
         # The open method depends on the compressed flag
         if self.compressed:
-            return gzip.open(self.filepath, 'rb')
+            return cast(IO, gzip.open(self.filepath, 'rb'))
         else:
             return open(self.filepath, 'r')
 

--- a/vizier/mimir.py
+++ b/vizier/mimir.py
@@ -103,23 +103,22 @@ def createLens(dataset, params, type, materialize, human_readable_name = None, p
     resp = readResponse(requests.post(_mimir_url + 'lens/create', json=req_json))
     return resp
 
-def createView(dataset, 
+def createView(
+    datasets: Dict[str, str], 
     query: str, 
-    properties: Optional[Dict[str, Any]] = None
-  ):
+    properties: Optional[Dict[str, Any]] = None,
+    functions: Optional[Dict[str, str]] = None
+  ) -> Tuple[str, List[str], List[Dict[str, Any]], Dict[str, Any], List[str]]:
     properties = {} if properties is None else properties
-    depts = None
-    if isinstance(dataset, dict):
-        depts = dataset
-    else:
-        depts = {dataset:dataset}
     req_json = {
-      "input": depts,
+      "input": datasets,
       "query": query,
       "properties" : properties
     }
+    if functions is not None:
+      req_json["functions"] = functions
     resp = readResponse(requests.post(_mimir_url + 'view/create', json=req_json))
-    return (resp['name'], resp['dependencies'], resp['schema'], resp['properties'])
+    return (resp['name'], resp['dependencies'], resp['schema'], resp['properties'], resp['functions'])
 
 def createAdaptiveSchema(dataset, params, type):
     req_json = {


### PR DESCRIPTION
(closes: https://github.com/VizierDB/web-ui/issues/225)
(depends on: https://github.com/UBOdin/mimir-api/pull/30)

- Fixing some typechecking issues, and added type annotations for components I touched.
- Added optional 'return_type' field to vizierdb.export_module
- SQL cells now pass a list of UDFs to the client
- Mimir's createView now passes functions

